### PR TITLE
setup.py README.rst does not exist, changed to README.md, KafkaUnavailableError was not defined in green_consumer, added import

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ here = os.path.abspath(os.path.dirname(__file__))
 with open('VERSION', 'r') as v:
     __version__ = v.read().rstrip()
 
-with open(os.path.join(here, 'README.rst')) as f:
+with open(os.path.join(here, 'README.md')) as f:
     README = f.read()
 
 

--- a/woof/green_consumer.py
+++ b/woof/green_consumer.py
@@ -2,7 +2,7 @@ from gevent import monkey; monkey.patch_all()
 import threading, logging, gevent, time
 
 from kafka import KafkaConsumer
-
+from kafka.common import KafkaUnavailableError
 log = logging.getLogger("kafka")
 
 class GreenFeedConsumer(threading.Thread):


### PR DESCRIPTION
setup.py README.rst does not exist, changed to README.md, KafkaUnavailableError was not defined in green_consumer, added import
